### PR TITLE
Fixing declaration of __init__ of LokiClient Class

### DIFF
--- a/loki_client/LokiClient.py
+++ b/loki_client/LokiClient.py
@@ -21,7 +21,7 @@ class LokiClient(object):
     Loki client for Python to communicate with Loki server.
     Ref: https://grafana.com/docs/loki/v2.4/api/
     """
-    def __int__(self,
+    def __init__(self,
                 url: str = "http://127.0.0.1:3100",
                 headers: dict = None,
                 disable_ssl: bool = True,


### PR DESCRIPTION
The init method of LokiClient was written as __int__ which caused the class to not be usable.